### PR TITLE
feat: add HTTP API server for image generation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,11 +30,19 @@ serde_json = { version = "1.0", optional = true }
 open = { version = "5.0", optional = true }
 rand = { version = "0.9", optional = true }
 
+# Server dependencies (optional, for HTTP API)
+axum = { version = "0.8", optional = true, features = ["json"] }
+tokio = { version = "1", optional = true, features = ["full"] }
+serde = { version = "1", optional = true, features = ["derive"] }
+uuid = { version = "1", optional = true, features = ["v4"] }
+tower-http = { version = "0.6", optional = true, features = ["cors"] }
+
 [features]
 default = ["wgpu"]
 egui = ["dep:eframe", "dep:egui_extras", "dep:rfd", "dep:reqwest", "dep:directories", "dep:chrono", "dep:serde_json", "dep:open", "dep:rand"]
 train = ["burn/autodiff", "burn/train", "dep:serde_json"]
 video = ["dep:longcat-burn", "dep:umt5-burn"]
+server = ["dep:axum", "dep:tokio", "dep:serde", "dep:uuid", "dep:tower-http", "dep:serde_json"]
 
 # Backend features - choose ONE when building
 # macOS (Metal via Candle): cargo build --release --features metal
@@ -119,3 +127,8 @@ path = "src/bin/generate_from_embedding.rs"
 name = "gui_lowmem"
 path = "src/bin/gui_lowmem.rs"
 required-features = ["egui"]
+
+[[bin]]
+name = "z-image-server"
+path = "src/bin/server.rs"
+required-features = ["server"]

--- a/src/bin/server.rs
+++ b/src/bin/server.rs
@@ -1,0 +1,211 @@
+#![recursion_limit = "256"]
+//! Z-Image Server - HTTP API for image generation
+//!
+//! Build:
+//!   cargo build --release --features "server,metal"
+//!
+//! Run:
+//!   z-image-server --model-dir /path/to/models --port 8080
+
+use std::collections::HashMap;
+use std::net::SocketAddr;
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize};
+use std::sync::{Arc, RwLock};
+
+use axum::routing::{get, post};
+use axum::Router;
+use tower_http::cors::CorsLayer;
+
+#[path = "../server/mod.rs"]
+mod server;
+
+use server::handlers;
+use server::queue;
+use server::state::AppState;
+
+// Backend selection based on compile-time features (same pattern as gui.rs / lib.rs)
+#[cfg(feature = "metal")]
+mod backend {
+    use burn::backend::candle::{Candle, CandleDevice};
+    use half::bf16;
+    pub type Backend = Candle<bf16, i64>;
+    pub type Device = CandleDevice;
+    pub fn create_device() -> Device {
+        CandleDevice::metal(0)
+    }
+    pub const BACKEND_NAME: &str = "Metal (Candle)";
+}
+
+#[cfg(feature = "cuda")]
+#[cfg(not(feature = "metal"))]
+mod backend {
+    use burn::backend::candle::{Candle, CandleDevice};
+    use half::bf16;
+    pub type Backend = Candle<bf16, i64>;
+    pub type Device = CandleDevice;
+    pub fn create_device() -> Device {
+        CandleDevice::cuda(0)
+    }
+    pub const BACKEND_NAME: &str = "CUDA (Candle)";
+}
+
+#[cfg(any(feature = "wgpu", feature = "wgpu-metal", feature = "vulkan"))]
+#[cfg(not(any(feature = "metal", feature = "cuda")))]
+mod backend {
+    use burn::backend::wgpu::{Wgpu, WgpuDevice};
+    pub type Backend = Wgpu<f32, i32>;
+    pub type Device = WgpuDevice;
+    pub fn create_device() -> Device {
+        WgpuDevice::default()
+    }
+    pub const BACKEND_NAME: &str = "WGPU";
+}
+
+#[cfg(feature = "cpu")]
+#[cfg(not(any(
+    feature = "metal",
+    feature = "cuda",
+    feature = "wgpu",
+    feature = "wgpu-metal",
+    feature = "vulkan"
+)))]
+mod backend {
+    use burn::backend::ndarray::{NdArray, NdArrayDevice};
+    pub type Backend = NdArray<f32>;
+    pub type Device = NdArrayDevice;
+    pub fn create_device() -> Device {
+        NdArrayDevice::Cpu
+    }
+    pub const BACKEND_NAME: &str = "CPU (NdArray)";
+}
+
+#[cfg(not(any(
+    feature = "metal",
+    feature = "cuda",
+    feature = "wgpu",
+    feature = "wgpu-metal",
+    feature = "vulkan",
+    feature = "cpu"
+)))]
+mod backend {
+    use burn::backend::ndarray::{NdArray, NdArrayDevice};
+    pub type Backend = NdArray<f32>;
+    pub type Device = NdArrayDevice;
+    pub fn create_device() -> Device {
+        NdArrayDevice::Cpu
+    }
+    pub const BACKEND_NAME: &str = "CPU (fallback)";
+}
+
+type Backend = backend::Backend;
+
+fn parse_args() -> (PathBuf, u16, PathBuf) {
+    let args: Vec<String> = std::env::args().collect();
+    let mut model_dir = PathBuf::from("models");
+    let mut port: u16 = 8080;
+    let mut output_dir = PathBuf::from("output");
+
+    let mut i = 1;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--model-dir" | "-m" => {
+                i += 1;
+                if i < args.len() {
+                    model_dir = PathBuf::from(&args[i]);
+                }
+            }
+            "--port" | "-p" => {
+                i += 1;
+                if i < args.len() {
+                    port = args[i].parse().unwrap_or(8080);
+                }
+            }
+            "--output-dir" | "-o" => {
+                i += 1;
+                if i < args.len() {
+                    output_dir = PathBuf::from(&args[i]);
+                }
+            }
+            "--help" | "-h" => {
+                eprintln!("z-image-server - HTTP API for Z-Image generation");
+                eprintln!();
+                eprintln!("Usage: z-image-server [OPTIONS]");
+                eprintln!();
+                eprintln!("Options:");
+                eprintln!("  -m, --model-dir <DIR>   Model directory (default: models)");
+                eprintln!("  -p, --port <PORT>       Port to listen on (default: 8080)");
+                eprintln!("  -o, --output-dir <DIR>  Output directory for images (default: output)");
+                eprintln!("  -h, --help              Show this help");
+                std::process::exit(0);
+            }
+            _ => {
+                eprintln!("Unknown argument: {}", args[i]);
+            }
+        }
+        i += 1;
+    }
+
+    (model_dir, port, output_dir)
+}
+
+#[tokio::main]
+async fn main() {
+    let (model_dir, port, output_dir) = parse_args();
+
+    eprintln!("=== Z-Image Server ===");
+    eprintln!("Backend:    {}", backend::BACKEND_NAME);
+    eprintln!("Model dir:  {:?}", model_dir);
+    eprintln!("Output dir: {:?}", output_dir);
+    eprintln!("Port:       {}", port);
+    eprintln!();
+
+    // Shared state
+    let tasks = Arc::new(RwLock::new(HashMap::new()));
+    let models_loaded = Arc::new(AtomicBool::new(false));
+
+    // Job channel
+    let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
+
+    // App state
+    let state = Arc::new(AppState {
+        tasks: tasks.clone(),
+        job_sender: tx,
+        models_loaded: models_loaded.clone(),
+        backend_name: backend::BACKEND_NAME.to_string(),
+        output_dir: output_dir.clone(),
+        num_steps: Arc::new(AtomicUsize::new(8)),
+        seed: Arc::new(AtomicU64::new(0)),
+        use_seed: Arc::new(AtomicBool::new(false)),
+        low_memory: Arc::new(AtomicBool::new(false)),
+    });
+
+    // Spawn GPU worker on dedicated thread
+    queue::spawn_gpu_worker::<Backend>(
+        rx,
+        tasks,
+        models_loaded,
+        model_dir,
+        output_dir,
+        backend::create_device,
+    );
+
+    // Build router
+    let app = Router::new()
+        .route("/generate", post(handlers::generate))
+        .route("/tasks/{id}", get(handlers::get_task))
+        .route("/images/{id}", get(handlers::get_image))
+        .route("/status", get(handlers::status))
+        .route("/settings", post(handlers::update_settings))
+        .layer(CorsLayer::permissive())
+        .with_state(state);
+
+    // Start server
+    let addr = SocketAddr::from(([0, 0, 0, 0], port));
+    eprintln!("Listening on http://{}", addr);
+    eprintln!("Models are loading in the background...");
+    eprintln!();
+
+    let listener = tokio::net::TcpListener::bind(addr).await.unwrap();
+    axum::serve(listener, app).await.unwrap();
+}

--- a/src/server/handlers.rs
+++ b/src/server/handlers.rs
@@ -1,0 +1,182 @@
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
+
+use axum::extract::{Path, State};
+use axum::http::StatusCode;
+use axum::response::IntoResponse;
+use axum::Json;
+
+use super::models::*;
+use super::state::*;
+
+/// POST /generate - Submit a new image generation job
+pub async fn generate(
+    State(state): State<Arc<AppState>>,
+    Json(req): Json<GenerateRequest>,
+) -> impl IntoResponse {
+    let task_id = uuid::Uuid::new_v4().to_string();
+
+    // Use per-request overrides or fall back to server defaults
+    let steps = req.steps.or_else(|| Some(state.get_steps()));
+    let seed = req.seed.or_else(|| state.get_seed());
+
+    let job = GenerationJob {
+        task_id: task_id.clone(),
+        prompt: req.prompt.clone(),
+        width: req.width,
+        height: req.height,
+        steps,
+        seed,
+    };
+
+    // Register task
+    {
+        let mut tasks = state.tasks.write().unwrap();
+        tasks.insert(
+            task_id.clone(),
+            TaskInfo {
+                task_id: task_id.clone(),
+                prompt: req.prompt,
+                status: TaskStatus::Queued,
+                output_path: None,
+                error: None,
+            },
+        );
+    }
+
+    // Send to GPU worker
+    if let Err(e) = state.job_sender.send(job) {
+        // Worker is down — mark task as failed
+        let mut tasks = state.tasks.write().unwrap();
+        if let Some(task) = tasks.get_mut(&task_id) {
+            task.status = TaskStatus::Failed;
+            task.error = Some(format!("Failed to queue job: {}", e));
+        }
+        return (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(GenerateResponse {
+                task_id,
+                status: "failed".to_string(),
+            }),
+        );
+    }
+
+    (
+        StatusCode::ACCEPTED,
+        Json(GenerateResponse {
+            task_id,
+            status: "queued".to_string(),
+        }),
+    )
+}
+
+/// GET /tasks/:id - Poll task status
+pub async fn get_task(
+    State(state): State<Arc<AppState>>,
+    Path(task_id): Path<String>,
+) -> impl IntoResponse {
+    let tasks = state.tasks.read().unwrap();
+    match tasks.get(&task_id) {
+        Some(task) => {
+            let image_url = if task.status == TaskStatus::Completed {
+                Some(format!("/images/{}", task.task_id))
+            } else {
+                None
+            };
+
+            (
+                StatusCode::OK,
+                Json(TaskResponse {
+                    task_id: task.task_id.clone(),
+                    status: task.status.to_string(),
+                    prompt: task.prompt.clone(),
+                    image_url,
+                    error: task.error.clone(),
+                }),
+            )
+        }
+        None => (
+            StatusCode::NOT_FOUND,
+            Json(TaskResponse {
+                task_id,
+                status: "not_found".to_string(),
+                prompt: String::new(),
+                image_url: None,
+                error: Some("Task not found".to_string()),
+            }),
+        ),
+    }
+}
+
+/// GET /images/:id - Serve generated image as PNG
+pub async fn get_image(
+    State(state): State<Arc<AppState>>,
+    Path(task_id): Path<String>,
+) -> impl IntoResponse {
+    let tasks = state.tasks.read().unwrap();
+    match tasks.get(&task_id) {
+        Some(task) if task.status == TaskStatus::Completed => {
+            if let Some(ref path) = task.output_path {
+                match std::fs::read(path) {
+                    Ok(data) => {
+                        return (
+                            StatusCode::OK,
+                            [("content-type", "image/png")],
+                            data,
+                        )
+                            .into_response();
+                    }
+                    Err(e) => {
+                        return (
+                            StatusCode::INTERNAL_SERVER_ERROR,
+                            format!("Failed to read image: {}", e),
+                        )
+                            .into_response();
+                    }
+                }
+            }
+            (StatusCode::NOT_FOUND, "Image file not found").into_response()
+        }
+        Some(task) => (
+            StatusCode::BAD_REQUEST,
+            format!("Task is not completed yet (status: {})", task.status),
+        )
+            .into_response(),
+        None => (StatusCode::NOT_FOUND, "Task not found").into_response(),
+    }
+}
+
+/// GET /status - Health check / server status
+pub async fn status(State(state): State<Arc<AppState>>) -> impl IntoResponse {
+    Json(StatusResponse {
+        models_loaded: state.models_loaded.load(Ordering::Acquire),
+        backend: state.backend_name.clone(),
+        queue_depth: state.queue_depth(),
+    })
+}
+
+/// POST /settings - Update generation settings
+pub async fn update_settings(
+    State(state): State<Arc<AppState>>,
+    Json(req): Json<SettingsRequest>,
+) -> impl IntoResponse {
+    if let Some(steps) = req.steps {
+        state.set_steps(steps);
+    }
+    if let Some(seed) = req.seed {
+        if seed == 0 {
+            state.set_seed(None);
+        } else {
+            state.set_seed(Some(seed));
+        }
+    }
+    if let Some(low_memory) = req.low_memory {
+        state.set_low_memory(low_memory);
+    }
+
+    Json(SettingsResponse {
+        steps: state.get_steps(),
+        seed: state.get_seed(),
+        low_memory: state.get_low_memory(),
+    })
+}

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1,0 +1,4 @@
+pub mod handlers;
+pub mod models;
+pub mod queue;
+pub mod state;

--- a/src/server/models.rs
+++ b/src/server/models.rs
@@ -1,0 +1,58 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Deserialize)]
+pub struct GenerateRequest {
+    pub prompt: String,
+    #[serde(default = "default_width")]
+    pub width: usize,
+    #[serde(default = "default_height")]
+    pub height: usize,
+    pub steps: Option<usize>,
+    pub seed: Option<u64>,
+}
+
+fn default_width() -> usize {
+    512
+}
+
+fn default_height() -> usize {
+    512
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct GenerateResponse {
+    pub task_id: String,
+    pub status: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct TaskResponse {
+    pub task_id: String,
+    pub status: String,
+    pub prompt: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub image_url: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct StatusResponse {
+    pub models_loaded: bool,
+    pub backend: String,
+    pub queue_depth: usize,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct SettingsRequest {
+    pub steps: Option<usize>,
+    pub seed: Option<u64>,
+    pub low_memory: Option<bool>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct SettingsResponse {
+    pub steps: usize,
+    pub seed: Option<u64>,
+    pub low_memory: bool,
+}

--- a/src/server/queue.rs
+++ b/src/server/queue.rs
@@ -1,0 +1,191 @@
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, RwLock};
+use std::time::Instant;
+
+use burn::tensor::backend::Backend;
+use tokio::sync::mpsc;
+
+use super::state::{GenerationJob, TaskInfo, TaskStatus};
+
+/// Starts the GPU worker on a dedicated OS thread.
+///
+/// The worker creates the device and loads all models on its own thread,
+/// then processes generation jobs from the channel sequentially.
+pub fn spawn_gpu_worker<B: Backend>(
+    mut rx: mpsc::UnboundedReceiver<GenerationJob>,
+    tasks: Arc<RwLock<HashMap<String, TaskInfo>>>,
+    models_loaded: Arc<AtomicBool>,
+    model_dir: PathBuf,
+    output_dir: PathBuf,
+    create_device: fn() -> B::Device,
+) {
+    std::thread::spawn(move || {
+        let device = create_device();
+
+        eprintln!(
+            "[server] GPU worker starting, loading models from {:?}...",
+            model_dir
+        );
+        let total_start = Instant::now();
+
+        // Load tokenizer
+        let tokenizer_path = find_tokenizer(&model_dir);
+        let tokenizer = match qwen3_burn::Qwen3Tokenizer::from_file(&tokenizer_path) {
+            Ok(t) => t,
+            Err(e) => {
+                eprintln!("[server] FATAL: Failed to load tokenizer: {}", e);
+                return;
+            }
+        };
+        eprintln!("[server] Tokenizer loaded");
+
+        // Load text encoder
+        let te_bpk = model_dir.join("qwen3_4b_text_encoder.bpk");
+        let te_safetensors = model_dir.join("qwen3_4b_text_encoder.safetensors");
+        let text_encoder_path = if te_bpk.exists() { te_bpk } else { te_safetensors };
+        let mut text_encoder: qwen3_burn::Qwen3Model<B> =
+            qwen3_burn::Qwen3Config::z_image_text_encoder().init(&device);
+        if let Err(e) = text_encoder.load_weights(&text_encoder_path) {
+            eprintln!("[server] FATAL: Failed to load text encoder: {:?}", e);
+            return;
+        }
+        eprintln!("[server] Text encoder loaded");
+
+        // Load transformer - prefer f16, then bf16, then safetensors
+        let transformer_path = find_model_file(&model_dir, &[
+            "z_image_turbo_f16",
+            "z_image_turbo_bf16",
+            "z_image_turbo",
+        ]);
+        eprintln!("[server] Loading transformer from {:?}...", transformer_path);
+        let mut transformer: z_image::modules::transformer::ZImageModel<B> =
+            z_image::modules::transformer::ZImageModelConfig::default().init(&device);
+        if let Err(e) = transformer.load_weights(&transformer_path) {
+            eprintln!("[server] FATAL: Failed to load transformer: {:?}", e);
+            return;
+        }
+        eprintln!("[server] Transformer loaded");
+
+        // Load autoencoder
+        let ae_bpk = model_dir.join("ae.bpk");
+        let ae_safetensors = model_dir.join("ae.safetensors");
+        let ae_path = if ae_bpk.exists() { ae_bpk } else { ae_safetensors };
+        let mut autoencoder: z_image::modules::ae::AutoEncoder<B> =
+            z_image::modules::ae::AutoEncoderConfig::flux_ae().init(&device);
+        if let Err(e) = autoencoder.load_weights(&ae_path) {
+            eprintln!("[server] FATAL: Failed to load autoencoder: {:?}", e);
+            return;
+        }
+        eprintln!("[server] Autoencoder loaded");
+
+        let load_time = total_start.elapsed().as_secs_f32();
+        eprintln!("[server] All models loaded in {:.2}s", load_time);
+        models_loaded.store(true, Ordering::Release);
+
+        // Create output directory
+        if let Err(e) = std::fs::create_dir_all(&output_dir) {
+            eprintln!(
+                "[server] Warning: Failed to create output directory: {}",
+                e
+            );
+        }
+
+        // Process jobs using a single-threaded tokio runtime for async channel recv
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("Failed to create tokio runtime for GPU worker");
+
+        rt.block_on(async {
+            while let Some(job) = rx.recv().await {
+                eprintln!(
+                    "[server] Processing job {} - prompt: \"{}\"",
+                    job.task_id, job.prompt
+                );
+
+                // Update status to processing
+                {
+                    let mut tasks_w = tasks.write().unwrap();
+                    if let Some(task) = tasks_w.get_mut(&job.task_id) {
+                        task.status = TaskStatus::Processing;
+                    }
+                }
+
+                let out_path = output_dir.join(format!("{}.png", job.task_id));
+                let gen_start = Instant::now();
+
+                let steps = job.steps.unwrap_or(8);
+                let opts = z_image::GenerateFromTextOpts {
+                    prompt: job.prompt.clone(),
+                    out_path: out_path.clone(),
+                    width: job.width,
+                    height: job.height,
+                    num_inference_steps: Some(steps),
+                    seed: job.seed,
+                };
+
+                let result = z_image::generate_from_text(
+                    &opts,
+                    &tokenizer,
+                    &text_encoder,
+                    &autoencoder,
+                    &transformer,
+                    &device,
+                );
+
+                let gen_time = gen_start.elapsed().as_secs_f32();
+
+                // Update task with result
+                let mut tasks_w = tasks.write().unwrap();
+                if let Some(task) = tasks_w.get_mut(&job.task_id) {
+                    match result {
+                        Ok(_) => {
+                            eprintln!(
+                                "[server] Job {} completed in {:.2}s",
+                                job.task_id, gen_time
+                            );
+                            task.status = TaskStatus::Completed;
+                            task.output_path = Some(out_path);
+                        }
+                        Err(e) => {
+                            let err_msg = format!("{:?}", e);
+                            eprintln!("[server] Job {} failed: {}", job.task_id, err_msg);
+                            task.status = TaskStatus::Failed;
+                            task.error = Some(err_msg);
+                        }
+                    }
+                }
+            }
+        });
+
+        eprintln!("[server] GPU worker shutting down");
+    });
+}
+
+fn find_tokenizer(model_dir: &PathBuf) -> PathBuf {
+    let p1 = model_dir.join("qwen3_tokenizer.json");
+    let p2 = model_dir.join("qwen3-tokenizer.json");
+    if p1.exists() {
+        p1
+    } else {
+        p2
+    }
+}
+
+/// Find a model file by trying multiple base names with .bpk then .safetensors extensions.
+fn find_model_file(model_dir: &PathBuf, base_names: &[&str]) -> PathBuf {
+    for name in base_names {
+        let bpk = model_dir.join(format!("{}.bpk", name));
+        if bpk.exists() {
+            return bpk;
+        }
+        let st = model_dir.join(format!("{}.safetensors", name));
+        if st.exists() {
+            return st;
+        }
+    }
+    // Fallback to first name with .bpk (will fail with a clear error)
+    model_dir.join(format!("{}.bpk", base_names[0]))
+}

--- a/src/server/state.rs
+++ b/src/server/state.rs
@@ -1,0 +1,103 @@
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
+use std::sync::{Arc, RwLock};
+
+use tokio::sync::mpsc;
+
+#[derive(Debug, Clone)]
+pub struct TaskInfo {
+    pub task_id: String,
+    pub prompt: String,
+    pub status: TaskStatus,
+    pub output_path: Option<PathBuf>,
+    pub error: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum TaskStatus {
+    Queued,
+    Processing,
+    Completed,
+    Failed,
+}
+
+impl std::fmt::Display for TaskStatus {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            TaskStatus::Queued => write!(f, "queued"),
+            TaskStatus::Processing => write!(f, "processing"),
+            TaskStatus::Completed => write!(f, "completed"),
+            TaskStatus::Failed => write!(f, "failed"),
+        }
+    }
+}
+
+pub struct GenerationJob {
+    pub task_id: String,
+    pub prompt: String,
+    pub width: usize,
+    pub height: usize,
+    pub steps: Option<usize>,
+    pub seed: Option<u64>,
+}
+
+pub struct AppState {
+    pub tasks: Arc<RwLock<HashMap<String, TaskInfo>>>,
+    pub job_sender: mpsc::UnboundedSender<GenerationJob>,
+    pub models_loaded: Arc<AtomicBool>,
+    pub backend_name: String,
+    pub output_dir: PathBuf,
+    // Settings
+    pub num_steps: Arc<AtomicUsize>,
+    pub seed: Arc<AtomicU64>,
+    pub use_seed: Arc<AtomicBool>,
+    pub low_memory: Arc<AtomicBool>,
+}
+
+impl AppState {
+    pub fn queue_depth(&self) -> usize {
+        let tasks = self.tasks.read().unwrap();
+        tasks
+            .values()
+            .filter(|t| t.status == TaskStatus::Queued || t.status == TaskStatus::Processing)
+            .count()
+    }
+
+    pub fn get_steps(&self) -> usize {
+        self.num_steps.load(Ordering::Relaxed)
+    }
+
+    pub fn get_seed(&self) -> Option<u64> {
+        if self.use_seed.load(Ordering::Relaxed) {
+            Some(self.seed.load(Ordering::Relaxed))
+        } else {
+            None
+        }
+    }
+
+    pub fn set_steps(&self, steps: usize) {
+        let steps = steps.clamp(1, 50);
+        self.num_steps.store(steps, Ordering::Relaxed);
+    }
+
+    pub fn set_seed(&self, seed: Option<u64>) {
+        match seed {
+            Some(s) => {
+                self.seed.store(s, Ordering::Relaxed);
+                self.use_seed.store(true, Ordering::Relaxed);
+            }
+            None => {
+                self.use_seed.store(false, Ordering::Relaxed);
+            }
+        }
+    }
+
+    pub fn set_low_memory(&self, enabled: bool) {
+        self.low_memory.store(enabled, Ordering::Relaxed);
+    }
+
+    pub fn get_low_memory(&self) -> bool {
+        self.low_memory.load(Ordering::Relaxed)
+    }
+}


### PR DESCRIPTION
## Summary
- Add `z-image-server` binary behind `server` feature flag
- Axum-based HTTP API with 5 endpoints: POST /generate, GET /tasks/{id}, GET /images/{id}, GET /status, POST /settings
- Dedicated GPU worker thread loads models once at startup, processes jobs sequentially via mpsc channel
- CORS enabled for local development
- Smart model file detection: prefers f16, falls back to bf16/safetensors

## Usage
```sh
cargo build --release --features "server,metal"
z-image-server --model-dir /path/to/models --port 8080
curl -X POST http://localhost:8080/generate -H "Content-Type: application/json" -d '{"prompt": "a cat"}'
```

## Testing notes
Tested end-to-end on Metal backend. During testing we found and fixed an upstream burn-candle regression (tracel-ai/burn#4570, tracel-ai/burn#4571).

Closes #2